### PR TITLE
Fix issue fetching another user's vCard

### DIFF
--- a/packages/vcard/index.js
+++ b/packages/vcard/index.js
@@ -34,7 +34,9 @@ class VcardPlugin {
    */
   get(jid) {
     return this.iqCaller
-      .request(xml('iq', {type: 'get', to: jid}, xml('vCard', {xmlns: NS}, jid)))
+      .request(
+        xml('iq', {type: 'get', to: jid}, xml('vCard', {xmlns: NS}, jid))
+      )
       .then(r => parse(r).vCard)
   }
 

--- a/packages/vcard/index.js
+++ b/packages/vcard/index.js
@@ -34,7 +34,7 @@ class VcardPlugin {
    */
   get(jid) {
     return this.iqCaller
-      .request(xml('iq', {type: 'get'}, xml('vCard', {xmlns: NS}, jid)))
+      .request(xml('iq', {type: 'get', to: jid}, xml('vCard', {xmlns: NS}, jid)))
       .then(r => parse(r).vCard)
   }
 


### PR DESCRIPTION
According to XEP-0054: vcard-temp specification in order to get another user's vCard,
it is said to pass that user's bare JID as 'to' attribute on the 'iq' element.

Without 'to', it always seem to return own vCard.
https://xmpp.org/extensions/xep-0054.html#sect-idm46757230304784